### PR TITLE
Add MWCC PS2 .line section parser for source line info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Updated from [this fork](https://github.com/dbalatoni13/ghidra-dwarf1/tree/maste
 2. Anonymous enums/unions/structure/classes now will have unique names based on DIE offset in debug section
 3. Fixed and (slightly) expanded code for variable imporing 
 4. Added support for DWARF1 MWCC extensions. These were used by MetroWerks CodeWarrior PS2 SDK.
-5. Updated to Ghidra 11.3.2/11.4.2
-6. VSCode support
-7. Some QOL changes
+5. Added source line info support (MWCC PS2 `.line` section)
+6. Updated to Ghidra 11.3.2/11.4.2
+7. VSCode support
+8. Some QOL changes
 
 It may not work with other files, probably has some bugs and is incomplete. Use it on your own risk. 
 I suggest making a backup of your Ghidra database before using it, or work on fresh DB to be safe.

--- a/extension.properties
+++ b/extension.properties
@@ -1,5 +1,5 @@
 name=@extname@
 description=Parser/importer of DWARF1 debug information
-author=Rafal Harabien, dbalatoni13 & Zoi
+author=Rafal Harabien, dbalatoni13, Zoi & Andru
 createdOn=
 version=@extversion@

--- a/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1ImportUtils.java
+++ b/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1ImportUtils.java
@@ -3,10 +3,13 @@ package com.github.rafalh.ghidra.dwarfone;
 import java.io.IOException;
 import java.util.Optional;
 
+import com.github.rafalh.ghidra.dwarfone.model.AddrAttributeValue;
 import com.github.rafalh.ghidra.dwarfone.model.AttributeName;
 import com.github.rafalh.ghidra.dwarfone.model.BlockAttributeValue;
+import com.github.rafalh.ghidra.dwarfone.model.ConstAttributeValue;
 import com.github.rafalh.ghidra.dwarfone.model.DebugInfoEntry;
 import com.github.rafalh.ghidra.dwarfone.model.LocationDescription;
+import com.github.rafalh.ghidra.dwarfone.model.RefAttributeValue;
 import com.github.rafalh.ghidra.dwarfone.model.StringAttributeValue;
 
 import ghidra.app.util.bin.ByteArrayProvider;
@@ -16,6 +19,20 @@ public class DWARF1ImportUtils {
 		// empty
 	}
 	
+	/**
+	 * Extracts a numeric attribute that may be encoded as Const, Ref, or Addr form.
+	 * AT_stmt_list is one example where compilers differ in which form they use.
+	 */
+	static Optional<Long> extractNumericAttribute(DebugInfoEntry die, AttributeName name) {
+		var asConst = die.<ConstAttributeValue>getAttribute(name);
+		if (asConst.isPresent()) return Optional.of(asConst.get().get().longValue());
+		var asRef = die.<RefAttributeValue>getAttribute(name);
+		if (asRef.isPresent()) return Optional.of(asRef.get().get());
+		var asAddr = die.<AddrAttributeValue>getAttribute(name);
+		if (asAddr.isPresent()) return Optional.of(asAddr.get().get());
+		return Optional.empty();
+	}
+
 	static Optional<String> extractName(DebugInfoEntry die) {
 		return die.<StringAttributeValue>getAttribute(AttributeName.NAME)
 				.map(StringAttributeValue::get);

--- a/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1LineInfoImporter.java
+++ b/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1LineInfoImporter.java
@@ -1,0 +1,160 @@
+package com.github.rafalh.ghidra.dwarfone;
+
+import java.io.IOException;
+
+import com.github.rafalh.ghidra.dwarfone.model.AddrAttributeValue;
+import com.github.rafalh.ghidra.dwarfone.model.AttributeName;
+import com.github.rafalh.ghidra.dwarfone.model.ConstAttributeValue;
+import com.github.rafalh.ghidra.dwarfone.model.DebugInfoEntry;
+import com.github.rafalh.ghidra.dwarfone.model.RefAttributeValue;
+import com.github.rafalh.ghidra.dwarfone.model.StringAttributeValue;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.CommentType;
+import ghidra.program.model.listing.Listing;
+import ghidra.util.task.TaskMonitor;
+
+/**
+ * Parses the DWARF1 .line section (MWCC PS2 format) and attaches source
+ * file/line EOL comments to instruction addresses in the Ghidra listing.
+ *
+ * MWCC PS2 .line section layout:
+ *
+ *   Block header (8 bytes):
+ *     uint32  blockLength   total block size including this field
+ *     uint32  baseAddr      absolute base address for all entries in this block
+ *
+ *   Entries (10 bytes each), starting at offset 8:
+ *     uint16  line_number
+ *     uint16  zero          (always 0x0000)
+ *     uint16  0xFFFF        sentinel
+ *     uint16  delta_lo      byte offset from baseAddr (low 16 bits)
+ *     uint16  delta_hi      byte offset from baseAddr (high 16 bits, always 0)
+ *
+ *   Blocks are contiguous in the section.
+ *   An entry with line_number == 0 marks the end of the block's entries.
+ */
+public class DWARF1LineInfoImporter {
+
+    private static final int BLOCK_HEADER_SIZE = 8;  // blockLength(4) + baseAddr(4)
+    private static final int ENTRY_SIZE        = 10; // line(2) + zero(2) + ffff(2) + delta(4)
+
+    private final DWARF1Program dwarfProgram;
+    private final MessageLog log;
+    private final TaskMonitor monitor;
+
+    DWARF1LineInfoImporter(DWARF1Program dwarfProgram, MessageLog log, TaskMonitor monitor) {
+        this.dwarfProgram = dwarfProgram;
+        this.log = log;
+        this.monitor = monitor;
+    }
+
+    /**
+     * Processes a single COMPILE_UNIT DIE: reads its AT_stmt_list offset,
+     * then parses the corresponding block in the .line section.
+     */
+    void processCompileUnit(DebugInfoEntry cuDie, ByteProvider lineBp) throws IOException {
+        // AT_stmt_list can be encoded as DATA4 (Const), REF, or ADDR depending on compiler
+        long blockOffset;
+        var asConst = cuDie.<ConstAttributeValue>getAttribute(AttributeName.STMT_LIST);
+        if (asConst.isPresent()) {
+            blockOffset = asConst.get().get().longValue();
+        } else {
+            var asRef = cuDie.<RefAttributeValue>getAttribute(AttributeName.STMT_LIST);
+            if (asRef.isPresent()) {
+                blockOffset = asRef.get().get();
+            } else {
+                var asAddr = cuDie.<AddrAttributeValue>getAttribute(AttributeName.STMT_LIST);
+                if (asAddr.isPresent()) {
+                    blockOffset = asAddr.get().get();
+                } else {
+                    return;
+                }
+            }
+        }
+
+        String cuName = cuDie.<StringAttributeValue>getAttribute(AttributeName.NAME)
+                .map(StringAttributeValue::get)
+                .orElse(null);
+
+        parseLineBlock(lineBp, blockOffset, cuName);
+    }
+
+    private void parseLineBlock(ByteProvider bp, long blockOffset, String cuName) throws IOException {
+        long fileLen = bp.length();
+        if (blockOffset + BLOCK_HEADER_SIZE > fileLen) {
+            log.appendMsg(String.format("[DWARF1 .line] Block offset 0x%X out of bounds.", blockOffset));
+            return;
+        }
+
+        BinaryReader br = new BinaryReader(bp, dwarfProgram.isLittleEndian());
+        br.setPointerIndex(blockOffset);
+
+        long blockLength = br.readNextUnsignedInt();
+        if (blockLength < BLOCK_HEADER_SIZE + ENTRY_SIZE) {
+            return;
+        }
+
+        long baseAddr = br.readNextUnsignedInt();
+        if (baseAddr == 0 || baseAddr > 0xFFFFFFFFL) {
+            return;
+        }
+
+        long blockEnd = blockOffset + blockLength;
+        if (blockEnd > fileLen) {
+            blockEnd = fileLen;
+        }
+
+        String fileName = buildFileName(cuName);
+        Listing listing = dwarfProgram.getProgram().getListing();
+
+        while (br.getPointerIndex() + ENTRY_SIZE <= blockEnd) {
+            if (monitor.isCancelled()) {
+                break;
+            }
+
+            int  line    = br.readNextUnsignedShort(); // line number
+            br.readNextUnsignedShort();                // zero
+            br.readNextUnsignedShort();                // 0xFFFF sentinel
+            long deltaLo = br.readNextUnsignedShort(); // delta low 16 bits
+            long deltaHi = br.readNextUnsignedShort(); // delta high 16 bits
+            long delta   = deltaLo | (deltaHi << 16);
+
+            if (line == 0 || line == 0xFFFF) {
+                continue;
+            }
+
+            long resolvedAddr = baseAddr + delta;
+            if (resolvedAddr > 0xFFFFFFFFL) {
+                continue;
+            }
+
+            Address addr = dwarfProgram.toAddr(resolvedAddr);
+            setEolComment(listing, addr, buildComment(fileName, line));
+        }
+    }
+
+    private static String buildFileName(String cuName) {
+        if (cuName == null) return null;
+        int slash = Math.max(cuName.lastIndexOf('/'), cuName.lastIndexOf('\\'));
+        return (slash >= 0) ? cuName.substring(slash + 1) : cuName;
+    }
+
+    private static String buildComment(String fileName, int lineNum) {
+        return (fileName != null ? fileName : "line") + ":" + lineNum;
+    }
+
+    private void setEolComment(Listing listing, Address addr, String comment) {
+        String existing = listing.getComment(CommentType.EOL, addr);
+        if (existing != null) {
+            if (existing.contains(comment)) {
+                return;
+            }
+            comment = existing + " | " + comment;
+        }
+        listing.setComment(addr, CommentType.EOL, comment);
+    }
+}

--- a/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1LineInfoImporter.java
+++ b/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1LineInfoImporter.java
@@ -2,11 +2,8 @@ package com.github.rafalh.ghidra.dwarfone;
 
 import java.io.IOException;
 
-import com.github.rafalh.ghidra.dwarfone.model.AddrAttributeValue;
 import com.github.rafalh.ghidra.dwarfone.model.AttributeName;
-import com.github.rafalh.ghidra.dwarfone.model.ConstAttributeValue;
 import com.github.rafalh.ghidra.dwarfone.model.DebugInfoEntry;
-import com.github.rafalh.ghidra.dwarfone.model.RefAttributeValue;
 import com.github.rafalh.ghidra.dwarfone.model.StringAttributeValue;
 
 import ghidra.app.util.bin.BinaryReader;
@@ -57,30 +54,16 @@ public class DWARF1LineInfoImporter {
      * then parses the corresponding block in the .line section.
      */
     void processCompileUnit(DebugInfoEntry cuDie, ByteProvider lineBp) throws IOException {
-        // AT_stmt_list can be encoded as DATA4 (Const), REF, or ADDR depending on compiler
-        long blockOffset;
-        var asConst = cuDie.<ConstAttributeValue>getAttribute(AttributeName.STMT_LIST);
-        if (asConst.isPresent()) {
-            blockOffset = asConst.get().get().longValue();
-        } else {
-            var asRef = cuDie.<RefAttributeValue>getAttribute(AttributeName.STMT_LIST);
-            if (asRef.isPresent()) {
-                blockOffset = asRef.get().get();
-            } else {
-                var asAddr = cuDie.<AddrAttributeValue>getAttribute(AttributeName.STMT_LIST);
-                if (asAddr.isPresent()) {
-                    blockOffset = asAddr.get().get();
-                } else {
-                    return;
-                }
-            }
+        var blockOffset = DWARF1ImportUtils.extractNumericAttribute(cuDie, AttributeName.STMT_LIST);
+        if (blockOffset.isEmpty()) {
+            return;
         }
 
         String cuName = cuDie.<StringAttributeValue>getAttribute(AttributeName.NAME)
                 .map(StringAttributeValue::get)
                 .orElse(null);
 
-        parseLineBlock(lineBp, blockOffset, cuName);
+        parseLineBlock(lineBp, blockOffset.get(), cuName);
     }
 
     private void parseLineBlock(ByteProvider bp, long blockOffset, String cuName) throws IOException {

--- a/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1ProgramAnalyzer.java
+++ b/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1ProgramAnalyzer.java
@@ -164,6 +164,7 @@ public class DWARF1ProgramAnalyzer {
             }
         }
     }
+
     /**
      * Processes a DebugInfoEntry, dispatching to appropriate importers or
      * recursively processing its children if it's a structural tag like

--- a/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1ProgramAnalyzer.java
+++ b/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1ProgramAnalyzer.java
@@ -50,7 +50,8 @@ public class DWARF1ProgramAnalyzer {
                 log.appendMsg("No DWARF1 debug section found.");
                 return false;
             }
-            processDebugSection(debug);
+            var line = sectionProvider.getSectionAsByteProvider(DWARF1SectionNames.LINE, monitor);
+            processDebugSection(debug, line);
             return true;
         } catch (IOException e) {
             log.appendException(e);
@@ -62,7 +63,7 @@ public class DWARF1ProgramAnalyzer {
         return !program.getLanguage().isBigEndian();
     }
 
-    private void processDebugSection(ByteProvider bp) throws IOException {
+    private void processDebugSection(ByteProvider bp, ByteProvider lineBp) throws IOException {
         BinaryReader br = new BinaryReader(bp, isLittleEndian());
         
         Stack<DebugInfoEntry> parentStack = new Stack<>(); 
@@ -142,8 +143,26 @@ public class DWARF1ProgramAnalyzer {
             processTopLevelDebugInfoEntry(die); 
         }
 
-        dwarfVariableImporter.processDeferredVariables();   
+        dwarfVariableImporter.processDeferredVariables();
 
+        if (lineBp != null) {
+            processLineSection(topLevelDies, lineBp);
+        }
+    }
+
+    private void processLineSection(List<DebugInfoEntry> topLevelDies, ByteProvider lineBp) {
+        monitor.setMessage("Processing DWARF1 .line section...");
+        var lineImporter = new DWARF1LineInfoImporter(dwarfProgram, log, monitor);
+        for (DebugInfoEntry die : topLevelDies) {
+            if (die.getTag() == Tag.COMPILE_UNIT) {
+                try {
+                    lineImporter.processCompileUnit(die, lineBp);
+                } catch (IOException e) {
+                    log.appendMsg("[DWARF1 .line] Error processing compile unit at 0x" +
+                            Long.toHexString(die.getRef()) + ": " + e.getMessage());
+                }
+            }
+        }
     }
     /**
      * Processes a DebugInfoEntry, dispatching to appropriate importers or

--- a/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1SectionNames.java
+++ b/src/main/java/com/github/rafalh/ghidra/dwarfone/DWARF1SectionNames.java
@@ -2,7 +2,8 @@ package com.github.rafalh.ghidra.dwarfone;
 
 public class DWARF1SectionNames {
 	public static final String DEBUG = "debug";
-	
+	public static final String LINE = "line";
+
 	private DWARF1SectionNames() {
 		// empty
 	}


### PR DESCRIPTION
# Add MWCC PS2 `.line` section support (source line info)

## Summary

- Parses the DWARF1 `.line` section as produced by MetroWerks CodeWarrior for PS2 and attaches `filename:line` EOL comments to instruction addresses in the Ghidra listing
- Reads `AT_stmt_list` from each `COMPILE_UNIT` DIE to locate its block in the `.line` section
- Added `extractNumericAttribute()` helper in `DWARF1ImportUtils` to handle `AT_stmt_list` encoded as Const, Ref, or Addr form (compilers differ)
- Updated README

## Format

The MWCC PS2 `.line` section uses a block-per-compile-unit layout:

```
Block header (8 bytes):
  uint32  blockLength   total block size including this field
  uint32  baseAddr      absolute base address for all entries in this block

Entries (10 bytes each):
  uint16  line_number
  uint16  zero
  uint16  0xFFFF        sentinel
  uint16  delta_lo      byte offset from baseAddr (low 16 bits)
  uint16  delta_hi      byte offset from baseAddr (high 16 bits, always 0)
```

## Testing

Tested on a MWCC-compiled PS2 binary. Ghidra listing shows comments like `Performance.cpp:237` on the corresponding instruction addresses.

<img width="979" height="855" alt="imagen" src="https://github.com/user-attachments/assets/e45c8cf3-4685-4ffc-9acd-ef74b30f92ab" />

---
Developed with AI assistance, reviewed and tested by the author.